### PR TITLE
Fixed data-response-url check with hash

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -224,7 +224,7 @@
 			var responseUrl = htmldata.find(ROOT + ' > [data-response-url]')
 				.attr('data-response-url');
 			
-			if (!!responseUrl && responseUrl != obj) {
+			if (!!responseUrl && responseUrl != obj.split('#')[0]) {
 				
 				var redirectedPage = nextPage;
 				


### PR DESCRIPTION
Strip hash from opbject to compare againt data-response-url beacause an hash does not represent a page change, only a scroll position change