### PR TITLE
Delay loadOneAsset() until the next loop

### DIFF
--- a/src/app-loader.js
+++ b/src/app-loader.js
@@ -193,7 +193,7 @@
 	recursiveLoad = function () {
 		if (!!assets.length) {
 			// start next one
-			loadOneAsset();
+			setTimeout(loadOneAsset, 0);
 		} else {
 			// work is done
 			loaderIsWorking = false;


### PR DESCRIPTION
This prevents creating a new XHR object in a XHR callback, and make sure
all sync code in the callback is ended.