### PR TITLE
Deal better with client errors (4xx)

### DIFF
--- a/src/app-loader.js
+++ b/src/app-loader.js
@@ -128,7 +128,7 @@
 					}
 				}
 			},
-			error: function () {
+			error: function (jqXHR, textStatus, errorThrown) {
 				var maxRetriesFactor = !!asset.vip ? 2 : 1;
 				
 				// clear pointer
@@ -143,12 +143,15 @@
 				asset.priority += ++asset.retries; // out of bounds checking is done later
 				//}
 				
-				// @todo: check for the error code
-				// and do something smart with it
-				// 404 will sometimes wait for timeout, so it's better to skip it fast
-				
+				// Check the error code:
+				// No need to replay client errors (4xx)
+				var clientError = jqXHR.status >= 400 && jqXHR.status < 500;
+				if (!!clientError) {
+					// Early exit
+					App.callback(asset.clienterror, [jqXHR.status, jqXHR, textStatus, errorThrown]);
+
 				// if we already re-tried  less than x times
-				if (asset.retries <= (asset.maxRetries * maxRetriesFactor)) {
+				} else if (asset.retries <= (asset.maxRetries * maxRetriesFactor)) {
 					// push it back into the queue and retry
 					loadAsset(asset);
 				} else {

--- a/tests/framework.loader.js.test.html
+++ b/tests/framework.loader.js.test.html
@@ -60,11 +60,12 @@
 			
 			test('load', function loaderLoadTest () {
 				
-				var fisrtTest = function () {
+				var firstTest = function () {
 					var successCount = 0;
 					var errorCount = 0;
 					var completeCount = 0;
 					var giveup = 0;
+					var clienterror = 0;
 
 					stop();
 
@@ -80,18 +81,22 @@
 								errorCount++;
 							},
 							giveup: function () {
-								giveup++;
+								giveup++; // should not get called
+							},
+							clienterror: function () {
+								clienterror++;
 							},
 							complete: function () {
 								completeCount++;
 
-								// should be called at least 2 times
-								if (completeCount > 2) {
+								// should be called only once
+								if (completeCount === 1) {
 
 									start();
-									equal(giveup, 1, '1.html giveup count is 1');
+									equal(clienterror, 1, '1.html clienterror count is 1');
+									equal(giveup, 0, '1.html giveup count is 0');
 									equal(successCount, 0, '1.html successCount is 0');
-									equal(errorCount, 3, '1.html errorCount is 3');
+									equal(errorCount, 1, '1.html errorCount is 1');
 
 									secondTest();
 								}
@@ -224,7 +229,7 @@
 					stop();
 				};
 				
-				fisrtTest();
+				firstTest();
 			});
 		
 	})(jQuery, window);


### PR DESCRIPTION
This is a breacking-change: when the requests comes in with a 4xx
status, we do not try it again and bypass the 'giveup' callback, by
introducing a new callback: 'clienterror'.

Note that 'error' is still always called.

Fixes #12