### PR TITLE
Basic os detection of the holy trinity of operating systems

### DIFF
--- a/src/app-device.js
+++ b/src/app-device.js
@@ -269,6 +269,45 @@
 			 */
 			isChrome: function (userAgent) {
 				return testUserAgent(/Chrome/i, userAgent) && !detector.isEdge();
+			},
+
+			/**
+			 * Check if the user agent contains the word 'Macintosh' and it's not on mobile
+			 * @name isMacOs
+			 * @method
+			 * @memberof device
+			 * @param {String} userAgent The browser user agent
+			 * @returns {Boolean}
+			 * @private
+			 */
+			isMacOs: function (userAgent) {
+				return testUserAgent(/Macintosh/i, userAgent) && !detector.isMobile();
+			},
+
+			/**
+			 * Check if the user agent contains the word 'Windows'
+			 * @name isWindows
+			 * @method
+			 * @memberof device
+			 * @param {String} userAgent The browser user agent
+			 * @returns {Boolean}
+			 * @private
+			 */
+			isWindows: function (userAgent) {
+				return testUserAgent(/Windows/i, userAgent);
+			},
+
+			/**
+			 * Check if the user agent contains the word 'Linux' and it's not on mobile
+			 * @name isLinux
+			 * @method
+			 * @memberof device
+			 * @param {String} userAgent The browser user agent
+			 * @returns {Boolean}
+			 * @private
+			 */
+			isLinux: function (userAgent) {
+				return testUserAgent(/Linux/i, userAgent) && !detector.isMobile();
 			}
 		};
 		
@@ -324,6 +363,33 @@
 			 * @memberof device
 			 */
 			android: browserDetector.isAndroid(),
+
+			/**
+			 * Check if the device run on Max Os
+			 * @name macos
+			 * @constant
+			 * @public
+			 * @memberof device
+			 */
+			macos: browserDetector.isMacOs(),
+
+			/**
+			 * Check if the device run on Windows
+			 * @name windows
+			 * @constant
+			 * @public
+			 * @memberof device
+			 */
+			windows: browserDetector.isWindows(),
+
+			/**
+			 * Check if the device run on Linux
+			 * @name linux
+			 * @constant
+			 * @public
+			 * @memberof device
+			 */
+			linux: browserDetector.isLinux(),
 
 			/**
 			 * Check if the device is a mobile


### PR DESCRIPTION
This will be usefull of our custom _modernizer_ and since we already had it for android and ios, why not the desktop ones.

e.g. Styling of scrollbars on Windows only and let the others enjoy their scrollbar superiority. 😉

@PascalPiche @nitriques We should add it to the tests too. Where can I add it ?