### PR TITLE
Use memory cache to store pages and avoid keeping them in the DOM

### DIFF
--- a/src/app-mediator.js
+++ b/src/app-mediator.js
@@ -309,11 +309,10 @@
 				route = response.url;
 
 				const node = document.querySelector(nextPage.selector());
-				
+
 				// If the redirected page already exists re-use it else continue the normal flow.
 				if (!!node) {
-					node.style.opacity = 0;
-					node.style.display = 'none';
+					node.remove();
 					return enterLeave();
 				}
 			}
@@ -348,14 +347,13 @@
 						data: data,
 						url: obj,
 						response: response,
-						status: response.status,
+						status: response.status
 					});
 
 				} else {
-					// append it to the doc, hidden
-					node.style.opacity = 0;
-					node.style.display = 'none';
-
+					// add it to the cache
+					App.pages.setLoadedPage(nextPage.key(), node);
+					// append it to the doc
 					elem.appendChild(node);
 
 					/**
@@ -523,6 +521,11 @@
 		// initialize page variable
 		currentPage = page;
 		previousPage = previousPage || page;
+		// Add current page to cache
+		App.pages.setLoadedPage(
+			currentPage.key(),
+			document.querySelector(currentPage.selector())
+		);
 
 		/**
 		 * @event App#page:entering

--- a/src/app-mediator.js
+++ b/src/app-mediator.js
@@ -353,8 +353,6 @@
 				} else {
 					// add page node to the cache
 					nextPage.setNode(node);
-					// append it to the doc
-					// elem.appendChild(node);
 
 					/**
 					 * @event App#pages:loaded

--- a/src/app-mediator.js
+++ b/src/app-mediator.js
@@ -351,10 +351,10 @@
 					});
 
 				} else {
-					// add it to the cache
-					App.pages.setLoadedPage(nextPage.key(), node);
+					// add page node to the cache
+					nextPage.setNode(node);
 					// append it to the doc
-					elem.appendChild(node);
+					// elem.appendChild(node);
 
 					/**
 					 * @event App#pages:loaded
@@ -521,11 +521,8 @@
 		// initialize page variable
 		currentPage = page;
 		previousPage = previousPage || page;
-		// Add current page to cache
-		App.pages.setLoadedPage(
-			currentPage.key(),
-			document.querySelector(currentPage.selector())
-		);
+		// Cache initial page node
+		currentPage.setNode(document.querySelector(currentPage.selector()));
 
 		/**
 		 * @event App#page:entering

--- a/src/app-mediator.js
+++ b/src/app-mediator.js
@@ -312,7 +312,6 @@
 
 				// If the redirected page already exists re-use it else continue the normal flow.
 				if (!!node) {
-					node.remove();
 					return enterLeave();
 				}
 			}
@@ -351,8 +350,8 @@
 					});
 
 				} else {
-					// add page node to the cache
-					nextPage.setNode(node);
+					// Cache page as a dom string
+					nextPage.cache(node.outerHTML);
 
 					/**
 					 * @event App#pages:loaded
@@ -519,8 +518,8 @@
 		// initialize page variable
 		currentPage = page;
 		previousPage = previousPage || page;
-		// Cache initial page node
-		currentPage.setNode(document.querySelector(currentPage.selector()));
+		// Cache initial page as a dom string
+		currentPage.cache(document.querySelector(currentPage.selector()).outerHTML);
 
 		/**
 		 * @event App#page:entering

--- a/src/app-pages.js
+++ b/src/app-pages.js
@@ -16,7 +16,6 @@
 	const pageModels = {};
 	const pageInstances = {};
 	const activeRoutes = {};
-	const loadedPages = {};
 
 	/**
 	 * Creates and a new factory function based on the
@@ -46,6 +45,7 @@
 		const factory = function (pageData) {
 			let modelRef;
 			let isInited = false;
+			let node;
 
 			if (typeof model === 'object') {
 				modelRef = model;
@@ -95,9 +95,8 @@
 				model: () => key,
 				enter: (next, data) => {
 					const root = document.querySelector(App.root());
-					const p = loadedPages[pageData.key];
-					if (p) {
-						root.appendChild(p);
+					if (node) {
+						root.appendChild(node);
 					}
 					if (!!data.firstTime || data.type === 'pushState') {
 						window.scrollTo({
@@ -127,6 +126,10 @@
 				},
 				setInited: () => {
 					isInited = true;
+				},
+				node: () => node,
+				setNode: (htmlData) => {
+					node = htmlData
 				}
 			});
 
@@ -429,16 +432,12 @@
 		return createPage({key: href}, model, true);
 	};
 
-	const loaded = (url) => {
+	const loaded = (href) => {
 		return (
-			!!loadedPages[url] ||
+			!!pageInstances[href]?.node() ||
 			// The first loaded page is never in the cache, get it in the DOM.
-			!!document.querySelector(App.root()).querySelector('[data-page-url="' + url + '"]')
+			!!document.querySelector(App.root()).querySelector('[data-page-url="' + href + '"]')
 		);
-	};
-
-	const setLoadedPage = (url, node) => {
-		loadedPages[url] = node;
 	};
 
 	registerPageModel('default', createPageModel('default', {}, true), {});
@@ -550,18 +549,6 @@
 			 * @since 3.0.0
 			 */
 			loaded: loaded,
-
-			/**
-			 * Add a page to the memory cache
-			 * @name exports
-			 * @memberof pages
-			 * @method
-			 * @param {String} url the page url, to be used as key
-			 * @param {HTMLElement} node the page html data
-			 * @public
-			 * @since 3.0.0
-			 */
-			setLoadedPage: setLoadedPage,
 
 			/**
 			 * App pages routes


### PR DESCRIPTION
This PR is making a change to the way the client-side routing is currently working.

Instead of keeping already visited pages in the DOM and hiding them with CSS, they are cached in an object, using the page `key` as the object keys, and the DOM node as the value. This way, we can safely remove the page we're leaving from the DOM and re-append it from the cache if it is re-visited.

I think this is a better approach overall. I tested these changes and everything seems to be working, but I am not familiar with the entirety of the framework and it is very possible that I missed some things.